### PR TITLE
Issue #36 Add semicolon to ECMA scripts to prevent interpreter except…

### DIFF
--- a/org.jvoicexml.srgs/src/main/java/org/jvoicexml/srgs/MatchConsumption.java
+++ b/org.jvoicexml.srgs/src/main/java/org/jvoicexml/srgs/MatchConsumption.java
@@ -159,7 +159,7 @@ public class MatchConsumption {
         context.evaluateString(
                 workingScope,
                 "var out=new Object();\nvar rules=new Object();\n"
-                        + "var meta={current: function() {return {text:'', score:1.0}}};\n",
+                        + "var meta={current: function() {return {text:'', score:1.0};}};\n",
                 "SISR init from MatchConsumer", 0, null);
 
         if (executationCollection.size() != 1) {

--- a/org.jvoicexml.srgs/src/main/java/org/jvoicexml/srgs/sisr/GrammarContext.java
+++ b/org.jvoicexml.srgs/src/main/java/org/jvoicexml/srgs/sisr/GrammarContext.java
@@ -65,7 +65,7 @@ public class GrammarContext implements ExecutableSemanticInterpretation {
         context.evaluateString(
                 grammarScope,
                 "var out=new Object();\nvar rules=new Object();\n"
-                        + "var meta={current: function() {return {text:'', score:1.0}}};\n",
+                        + "var meta={current: function() {return {text:'', score:1.0};}};\n",
                 "SISR init from MatchConsumer", 0, null);
 
         executableSI.execute(context, grammarScope);
@@ -115,7 +115,7 @@ public class GrammarContext implements ExecutableSemanticInterpretation {
 
         parentContext.evaluateString(parentScope, "meta." + ruleName
                 + "=function() {return {text:'" + ruleMetaCurrent
-                + "', score:1.0}};", "Context:rule set meta." + ruleName, 0,
+                + "', score:1.0};};", "Context:rule set meta." + ruleName, 0,
                 null);
 
         if (ruleMetaCurrent.length() > 0) {
@@ -126,13 +126,13 @@ public class GrammarContext implements ExecutableSemanticInterpretation {
             if (parentMetaCurrent.length() == 0) {
                 parentContext.evaluateString(parentScope,
                         "meta.current=function() {return {text:'"
-                                + ruleMetaCurrent + "', score:1.0}};",
+                                + ruleMetaCurrent + "', score:1.0};};",
                         "AddToMatchedText:set meta1", 0, null);
             } else {
                 parentContext.evaluateString(parentScope,
                         "meta.current=function() {return {text:'"
                                 + parentMetaCurrent + " " + ruleMetaCurrent
-                                + "', score:1.0}};",
+                                + "', score:1.0};};",
                         "AddToMatchedText:set meta1", 0, null);
             }
         }

--- a/org.jvoicexml.srgs/src/test/java/org/jvoicexml/srgs/TestMatchConsumptionSisr.java
+++ b/org.jvoicexml.srgs/src/test/java/org/jvoicexml/srgs/TestMatchConsumptionSisr.java
@@ -4,8 +4,6 @@ import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.jvoicexml.srgs.MatchConsumption;
-import org.jvoicexml.srgs.SrgsSisrGrammar;
 import org.mozilla.javascript.Scriptable;
 
 /** Most SI tests */


### PR DESCRIPTION
Fixes committed in a389efae7cd1688238b0054c0f23d756c0b5ddfa, applied to other instances. I've just added required semicolons to the return statements defined in-line in MatchConsumption and GrammarContext