### PR TITLE
Issue #38 Fix broken config tests

### DIFF
--- a/org.jvoicexml.config/build.gradle
+++ b/org.jvoicexml.config/build.gradle
@@ -11,6 +11,11 @@ sourceSets {
             exclude '**'
         }
     }
+    test {
+        resources {
+            srcDir "src/main/config"
+        }
+    }
 }
 configurations {
     jvxmlConfiguration

--- a/org.jvoicexml.config/src/main/java/org/jvoicexml/config/ConfigurationFolderMonitor.java
+++ b/org.jvoicexml.config/src/main/java/org/jvoicexml/config/ConfigurationFolderMonitor.java
@@ -153,6 +153,7 @@ public final class ConfigurationFolderMonitor extends Thread {
                         LOGGER.warn(e.getMessage(), e);
                     }
                 }
+                key.reset(); // Reset to await further events on the file
             } catch (ClosedWatchServiceException | InterruptedException e1) {
                 return;
             }

--- a/org.jvoicexml.config/src/test/java/org/jvoicexml/config/TestBeansFilter.java
+++ b/org.jvoicexml.config/src/test/java/org/jvoicexml/config/TestBeansFilter.java
@@ -73,7 +73,7 @@ public final class TestBeansFilter {
         final XMLFilterImpl filter = new BeansFilter(parser.getXMLReader());
         filter.setContentHandler(th);
         final InputStream in =
-            new FileInputStream("../org.jvoicexml.config/unittests/config/test-implementation.xml");
+            new FileInputStream("../org.jvoicexml.config/src/test/resources/config/test-implementation.xml");
         final InputSource input = new InputSource(in);
         filter.parse(input);
         final String str = out.toString();

--- a/org.jvoicexml.config/src/test/java/org/jvoicexml/config/TestClasspathExtractor.java
+++ b/org.jvoicexml.config/src/test/java/org/jvoicexml/config/TestClasspathExtractor.java
@@ -56,13 +56,13 @@ public final class TestClasspathExtractor {
         final TransformerFactory factory = TransformerFactory.newInstance();
         final Transformer transformer = factory.newTransformer();
         final Source source =
-            new StreamSource("../org.jvoicexml.config/unittests/config/test-implementation.xml");
+            new StreamSource("../org.jvoicexml.config/src/test/resources/config/test-implementation.xml");
         final ClasspathExtractor extractor = new ClasspathExtractor();
         final Result result = new SAXResult(extractor);
         transformer.transform(source, result);
         final URL[] urls = extractor.getClasspathEntries();
         Assert.assertEquals(1, urls.length);
-        Assert.assertTrue(urls[0].toString().indexOf("unittests/classes") > 0);
+        Assert.assertTrue(urls[0].toString().indexOf("src/test/java") > 0);
     }
 
     /**
@@ -75,7 +75,7 @@ public final class TestClasspathExtractor {
         final TransformerFactory factory = TransformerFactory.newInstance();
         final Transformer transformer = factory.newTransformer();
         final Source source =
-            new StreamSource("../org.jvoicexml.config/unittests/config/test-implementation.xml");
+            new StreamSource("../org.jvoicexml.config/src/test/resources/config/test-implementation.xml");
         final ClasspathExtractor extractor = new ClasspathExtractor();
         final Result result = new SAXResult(extractor);
         transformer.transform(source, result);

--- a/org.jvoicexml.config/src/test/java/org/jvoicexml/config/TestConfigurationFolderMonitor.java
+++ b/org.jvoicexml.config/src/test/java/org/jvoicexml/config/TestConfigurationFolderMonitor.java
@@ -28,11 +28,13 @@ package org.jvoicexml.config;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.log4j.Logger;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.Timeout;
 
 /**
  * Test cases for {@link ConfigurationFolderMonitor}.
@@ -43,12 +45,24 @@ import org.junit.Test;
  */
 public final class TestConfigurationFolderMonitor
     implements ConfigurationFileChangedListener {
-    /** Logger for this class. */
-    private static final Logger LOGGER =
-        Logger.getLogger(TestConfigurationFolderMonitor.class);
 
-    /** Notifications about messages from the monitor. */
-    private Object lock;
+    /** Logger for this class. */
+    private static final Logger LOGGER = Logger.getLogger(TestConfigurationFolderMonitor.class);
+
+    private static final String EXISTING_FILE_NAME = "existing.xml";
+    private static final String NEW_FILE_NAME = "new.xml";
+
+    @Rule public Timeout globalTimeout= new Timeout(10, TimeUnit.SECONDS);
+    @Rule public TemporaryFolder monitoredFolder = new TemporaryFolder();
+
+    /**
+     * CountDownLatch for test setup steps. Begin assertions after:
+     * 1. File action (create / update / delete) and;
+     * 2. ConfigurationFolderMonitor has been notified
+     */
+    private CountDownLatch readyForAssertions = new CountDownLatch(2);
+
+    private File existingFile;
 
     /** The reported file. */
     private File reportedFile;
@@ -60,76 +74,80 @@ public final class TestConfigurationFolderMonitor
      * Setup the test environment.
      */
     @Before
-    public void setUp() {
-        lock = new Object();
+    public void setUp() throws Exception {
+        final ConfigurationFolderMonitor monitor = new ConfigurationFolderMonitor(monitoredFolder.getRoot());
+        monitor.addListener(this);
+        monitor.start();
+
+        existingFile = monitoredFolder.newFile(EXISTING_FILE_NAME);
+        Thread.sleep(500);
+
+        // Ignore notifications so far - reset the latch
+        readyForAssertions = new CountDownLatch(2);
     }
 
     /**
-     * Tests the configuration folder monitor.
-     * @throws Exception 
+     * Tests the configuration folder monitor is aware of new file add
+     * @throws Exception
      *         test failed
      */
-    @Test(timeout = 10000)
-    public void test() throws Exception {
-        final long delay = 500;
-        final File configFolder = new File(
-                "../org.jvoicexml.config/unittests/config");
-        final ConfigurationFolderMonitor monitor =
-                new ConfigurationFolderMonitor(configFolder);
-        monitor.addListener(this);
-        monitor.start();
-        synchronized (lock) {
-            lock.wait();
-        }
-        LOGGER.info(action + " on " + reportedFile);
-        Assert.assertEquals(new File(
-            "../org.jvoicexml.config/unittests/config/test-implementation.xml").getCanonicalPath(),
-            reportedFile.getCanonicalPath());
-        Assert.assertEquals("added", action);
-        reportedFile = null;
-        action = null;
-        final File file = new File(
-                "../org.jvoicexml.config/unittests/config/test.xml");
-        file.deleteOnExit();
+    @Test
+    public void testNewFileAdded() throws Exception {
 
-        // Added
-        Thread.sleep(100);
-        file.createNewFile();
-        synchronized (lock) {
-            lock.wait();
-        }
+        monitoredFolder.newFile(NEW_FILE_NAME);
+        readyForAssertions.countDown();
+        readyForAssertions.await();
+
         LOGGER.info("observed '" + action + "' on " + reportedFile);
-        Assert.assertEquals(file.getCanonicalPath(), reportedFile.getCanonicalPath());
-        Assert.assertEquals("added", action);
-        reportedFile = null;
-        action = null;
-        Thread.sleep(delay);
 
-        // Updated
-        Thread.sleep(100);
-        final FileWriter writer = new FileWriter(file);
+        File expectedFile = new File(monitoredFolder.getRoot(), NEW_FILE_NAME);
+        Assert.assertEquals(expectedFile, reportedFile);
+        Assert.assertEquals("added", action);
+    }
+
+
+    /**
+     * Tests the configuration folder monitor is aware of file updates
+     * @throws Exception
+     *         test failed
+     */
+    @Test
+    public void testFileUpdated() throws Exception {
+
+        final FileWriter writer = new FileWriter(existingFile);
         writer.write("test");
         writer.close();
-        synchronized (lock) {
-            lock.wait();
-        }
-        LOGGER.info("observed '" + action + "' on " + reportedFile);
-        Assert.assertEquals(file, reportedFile);
-        Assert.assertEquals("updated", action);
-        reportedFile = null;
-        action = null;
-        Thread.sleep(delay);
+        readyForAssertions.countDown();
+        readyForAssertions.await();
 
-        // removed
-        Thread.sleep(100);
-        file.delete();
-        synchronized (lock) {
-            lock.wait();
-        }
         LOGGER.info("observed '" + action + "' on " + reportedFile);
-        Assert.assertEquals(file, reportedFile);
+
+        File expectedFile = new File(monitoredFolder.getRoot(), EXISTING_FILE_NAME);
+        Assert.assertEquals(expectedFile, reportedFile);
+        Assert.assertEquals("updated", action);
+    }
+
+
+
+    /**
+     * Tests the configuration folder monitor is aware of file deletion
+     * @throws Exception
+     *         test failed
+     */
+    @Test
+    public void testFileDeleted() throws Exception {
+
+        existingFile.delete();
+        readyForAssertions.countDown();
+        readyForAssertions.await();
+
+        LOGGER.info("observed '" + action + "' on " + reportedFile);
+
+        File expectedFile = new File(monitoredFolder.getRoot(), EXISTING_FILE_NAME);
+        Assert.assertEquals(expectedFile, reportedFile);
         Assert.assertEquals("deleted", action);
     }
+
 
     /**
      * {@inheritDoc}
@@ -138,9 +156,7 @@ public final class TestConfigurationFolderMonitor
     public void fileAdded(final File file) {
         reportedFile = file;
         action = "added";
-        synchronized (lock) {
-            lock.notifyAll();
-        }
+        readyForAssertions.countDown();
     }
 
     /**
@@ -150,9 +166,7 @@ public final class TestConfigurationFolderMonitor
     public void fileUpdated(final File file) {
         reportedFile = file;
         action = "updated";
-        synchronized (lock) {
-            lock.notifyAll();
-        }
+        readyForAssertions.countDown();
     }
 
     /**
@@ -162,8 +176,6 @@ public final class TestConfigurationFolderMonitor
     public void fileRemoved(final File file) {
         reportedFile = file;
         action = "deleted";
-        synchronized (lock) {
-            lock.notifyAll();
-        }
+        readyForAssertions.countDown();
     }
 }

--- a/org.jvoicexml.config/src/test/java/org/jvoicexml/config/TestConfigurationFolderMonitorForExistingFiles.java
+++ b/org.jvoicexml.config/src/test/java/org/jvoicexml/config/TestConfigurationFolderMonitorForExistingFiles.java
@@ -1,0 +1,92 @@
+package org.jvoicexml.config;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.io.File;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Test cases for {@link ConfigurationFolderMonitor}.
+ *
+ * @author Dirk Schnelle-Walka
+ * @version $Revision$
+ * @since 0.7.6
+ */
+public class TestConfigurationFolderMonitorForExistingFiles implements ConfigurationFileChangedListener {
+
+    @Rule public Timeout globalTimeout= new Timeout(10, TimeUnit.SECONDS);
+
+    /** The reported file. */
+    private File reportedFile;
+
+    /** The reported action. */
+    private String action;
+
+    /**
+     * CountDownLatch for test setup steps. Begin assertions after:
+     * 1. File action (create / update / delete) and;
+     * 2. ConfigurationFolderMonitor has been notified
+     */
+    private CountDownLatch readyForAssertions = new CountDownLatch(2);
+
+    /**
+     * Tests the configuration folder monitor is aware of existing files
+     * @throws Exception
+     *         test failed
+     */
+    @Test
+    public void testExistingFileIsNotified() throws Exception {
+
+        // Monitor the (existing) config folder
+        final File configFolder = new File("../org.jvoicexml.config/src/test/resources/config");
+        final ConfigurationFolderMonitor monitor = new ConfigurationFolderMonitor(configFolder);
+        monitor.addListener(this);
+        monitor.start();
+
+        // Wait for notification that existing files were 'added'
+        readyForAssertions.countDown();
+        readyForAssertions.await();
+
+        // Check the notification
+        Assert.assertEquals(new File(
+                        "../org.jvoicexml.config/src/test/resources/config/test-implementation.xml").getCanonicalPath(),
+                reportedFile.getCanonicalPath());
+        Assert.assertEquals("added", action);
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void fileAdded(final File file) {
+        reportedFile = file;
+        action = "added";
+        readyForAssertions.countDown();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void fileUpdated(final File file) {
+        reportedFile = file;
+        action = "updated";
+        readyForAssertions.countDown();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void fileRemoved(final File file) {
+        reportedFile = file;
+        action = "deleted";
+        readyForAssertions.countDown();
+    }
+
+}

--- a/org.jvoicexml.config/src/test/java/org/jvoicexml/config/TestJVoiceXmlConfiguration.java
+++ b/org.jvoicexml.config/src/test/java/org/jvoicexml/config/TestJVoiceXmlConfiguration.java
@@ -52,7 +52,7 @@ public final class TestJVoiceXmlConfiguration {
     @BeforeClass
     public static void init() throws Exception {
         final File file = new File(
-                "../org.jvoicexml.config/unittests/config");
+                "../org.jvoicexml.config/src/test/resources/config");
         final String path = file.getCanonicalPath();
         System.setProperty("jvoicexml.config", path);
     }
@@ -68,7 +68,7 @@ public final class TestJVoiceXmlConfiguration {
             new JVoiceXmlConfiguration();
         final Collection<File> files =
             config.getConfigurationFiles("implementation");
-        final File dir = new File("../org.jvoicexml.config/unittests/config");
+        final File dir = new File("../org.jvoicexml.config/src/test/resources/config");
         final FilenameFilter filter = new FilenameFilter() {
             /**
              * {@inheritDoc}

--- a/org.jvoicexml.config/src/test/resources/config/test-implementation.xml
+++ b/org.jvoicexml.config/src/test/resources/config/test-implementation.xml
@@ -3,9 +3,9 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:noNamespaceSchemaLocation="jvxml-implementation-0-7.xsd">
   <repository>deschd</repository>
-  <classpath>unittests/classes</classpath>
+  <classpath>src/test/java</classpath>
   <beans:bean
-    class="org.jvoicexml.implementation.jvxml.DummyTelephonySupportFactory">
+    class="org.jvoicexml.implementation.jvxml.DesktopTelephonySupportFactory">
     <beans:property name="instances" value="1" />
   </beans:bean>
 </implementation>

--- a/org.jvoicexml.config/src/test/resources/log4j2.xml
+++ b/org.jvoicexml.config/src/test/resources/log4j2.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Configuration>
+    <Appenders>
+        <Console name="stdout" target="SYSTEM_OUT">
+            <PatternLayout>
+                <Pattern>%6r [%-20.20t] %-5p %30.30c (%6L) %x %m%n</Pattern>
+             </PatternLayout>
+        </Console>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org.jvoicexml" level="debug">
+        </Logger>
+
+        <Root level="warn">
+            <AppenderRef ref="stdout" />
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
Mostly updates to reflect new test folder location.

I've significantly refactored the TestConfigurationFolderMonitor as it didn't work and the threading produced inconsistent results. I've split the old test into four smaller tests to verify file add, update and delete in their own tests. The test for behaviour of existing tests was moved to new class TestConfigurationFolderMonitorForExistingFiles.

This has uncovered a bug in the TestConfigurationFolderMonitor where it would notify only the first change to a file after startup - now fixed.