### PR TITLE
Fix semantics of message/messageexpr in throw strategy

### DIFF
--- a/org.jvoicexml.profile.vxml21/src/main/java/org/jvoicexml/profile/vxml21/tagstrategy/AbstractTagStrategy.java
+++ b/org.jvoicexml.profile.vxml21/src/main/java/org/jvoicexml/profile/vxml21/tagstrategy/AbstractTagStrategy.java
@@ -207,6 +207,42 @@ abstract public class AbstractTagStrategy implements Cloneable, TagStrategy {
     /**
      * Retrieves the value of an attribute that may alternatively defined by an
      * evaluated expression.
+     *
+     * @param pure
+     *            the original name of the attribute
+     * @param expr
+     *            the name of the attribute that has been evaluated by the
+     *            scripting engine
+     * @return value of the attribute, or null if neither pure nor expr are defined
+     * @throws BadFetchError
+     *             if both of the attributes are defined
+     * @since 0.7.7
+     */
+    protected Object getOptionalAttributeWithAlternativeExpr(final DataModel model,
+            final String pure, final String expr) throws BadFetchError {
+        final boolean pureDefined = isAttributeDefined(model, pure);
+        final boolean exprDefined = isAttributeDefined(model, expr);
+
+        // Both are defined
+        if ((pureDefined && exprDefined)) {
+            throw new BadFetchError("Exactly one of '" + pure + "' or '" + expr
+                    + "' may be defined!");
+        }
+
+        if (pureDefined) {
+            return getAttribute(pure);
+        }
+
+        if (exprDefined) {
+            return getAttribute(expr);
+        }
+
+        return null;
+    }
+
+    /**
+     * Retrieves the value of an attribute that may alternatively defined by an
+     * evaluated expression.
      * 
      * @param pure
      *            the original name of the attribute

--- a/org.jvoicexml.profile.vxml21/src/main/java/org/jvoicexml/profile/vxml21/tagstrategy/ThrowStrategy.java
+++ b/org.jvoicexml.profile.vxml21/src/main/java/org/jvoicexml/profile/vxml21/tagstrategy/ThrowStrategy.java
@@ -86,7 +86,7 @@ final class ThrowStrategy
     public void validateAttributes(final DataModel model)
             throws ErrorEvent {
         event = (String) getAttributeWithAlternativeExpr(model, Throw.ATTRIBUTE_EVENT, Throw.ATTRIBUTE_EVENTEXPR);
-        message = (String) getAttributeWithAlternativeExpr(model,
+        message = (String) getOptionalAttributeWithAlternativeExpr(model,
                 Throw.ATTRIBUTE_MESSAGE, Throw.ATTRIBUTE_MESSAGEEXPR); 
     }
 


### PR DESCRIPTION
Whilst reviewing the VXML 2.0 spec, I noticed that there's a small difference in the wording of the "event"/"eventexpr" attribute and the "message/messageexpr" attribute for (at least) the <throw> tag.

Currently the `ThrowStrategy` handles both in the same way, but I believe that this is incorrect for "message"/"messageexpr".